### PR TITLE
Fix nested indentation when using Break

### DIFF
--- a/src/StructuredWriter.elm
+++ b/src/StructuredWriter.elm
@@ -63,8 +63,9 @@ writeIndented indent w =
                     ]
 
         Breaked items ->
-            --TODO INDENT
-            String.join ("\n" ++ asIndent indent) (List.map (writeIndented indent) items)
+            items
+                |> List.concatMap (writeIndented 0 >> String.split "\n")
+                |> String.join ("\n" ++ asIndent indent)
 
         Str s ->
             s

--- a/tests/StructuredWriterTests.elm
+++ b/tests/StructuredWriterTests.elm
@@ -54,4 +54,24 @@ suite =
             \() ->
                 Writer.write (Writer.join [ Writer.string "foo", Writer.string "bar" ])
                     |> Expect.equal "foobar"
+        , test "indented sep with breaking lines" <|
+            \() ->
+                Writer.indent 2
+                    (Writer.breaked
+                        [ Writer.string "foo"
+                        , Writer.indent 2
+                            (Writer.spaced
+                                [ Writer.string "bar"
+                                , Writer.sepBySpace True [ Writer.string "baz", Writer.string "qux" ]
+                                ]
+                            )
+                        ]
+                    )
+                    |> Writer.write
+                    |> Expect.equal
+                        (""
+                            ++ "  foo\n"
+                            ++ "    bar baz\n"
+                            ++ "     qux"
+                        )
         ]


### PR DESCRIPTION
With this structure:

```elm
indent 2
    (breaked
        [ string "foo"
        , indent 2
            (spaced
                [ string "bar"
                , sepBySpace True [ string "baz", string "qux" ]
                ]
            )
        ]
    )
```

structure-writer was outputting this:

```
  foo
      bar baz
     qux
```

instead of this

```
  foo
    bar baz
     qux
```

it was duplicating the indentation for the second line, and not adding indentation on the subsequent lines. This PR fixes that :)